### PR TITLE
KTB-14 parsing with RegEx

### DIFF
--- a/src/main/kotlin/Telegram.kt
+++ b/src/main/kotlin/Telegram.kt
@@ -14,12 +14,17 @@ fun main(args: Array<String>) {
         Thread.sleep(2000)
         val updates = getUpdates(botToken, updateId)
         println(updates)
-        val positionUpdateId = updates.lastIndexOf("update_id")
-        val startUpdateId = updates.indexOf(":", positionUpdateId)
-        val endUpdateId = updates.indexOf(",\n\"message\"", startUpdateId)
-        if (startUpdateId == -1 || endUpdateId == -1) continue
-        val resultUpdateId = updates.substring(startUpdateId + 1, endUpdateId)
-        updateId = resultUpdateId.toInt() + 1
+        val positionUpdateIdRegex = "\"update_id\":(.+?),".toRegex()
+        val matchResultUpdateId = positionUpdateIdRegex.find(updates)
+        val groupUpdateId = matchResultUpdateId?.groups
+        val resultId = groupUpdateId?.get(1)?.value ?: continue
+        updateId = resultId.toInt() + 1
+
+        val messageTextRegex ="\"text\":\"(.+?)\"".toRegex()
+        val matchResultText = messageTextRegex.find(updates)
+        val groupsText = matchResultText?.groups
+        val resultText = groupsText?.get(1)?.value
+        println(resultText)
     }
 }
 


### PR DESCRIPTION
Переписан парсинг 'update_id' с использованием RegEx. _(вместо substring)_
Так же, с помощью RegEx достаём и печатаем в консоль текст пользователя.

P.S.
сейчас уже у меня нет апдейта с несколькими сообщениями, поэтому не приходится искать последний 'update_id', как это было при substring, где мы использовали 'lastIndexOf()'.
Однако, вероятно может быть всякое. Поэтому родилась идея, при использовании RegEx, доставать "как бы" ВСЕ 'update_id' через 'findALL()', а потом брать последнее с помощью lastOrNull().
Имеет место такая реализация? или избыточно?